### PR TITLE
SOARAIS-2124 - Add RequiredNodeValidator support to OSS codeValidator

### DIFF
--- a/configuration/ccdaReferenceValidatorConfig.xml
+++ b/configuration/ccdaReferenceValidatorConfig.xml
@@ -1637,13 +1637,21 @@ Change History:
             <allowedValuesetOids>2.16.840.1.113883.1.11.12839</allowedValuesetOids>
         </validator>
     </expression>    
-
+    	
+    <expression xpathExpression="//v3:observation/v3:templateId[@root='2.16.840.1.113883.10.20.22.4.2' and @extension='2015-08-01']/ancestor::v3:observation[1]/v3:value[@xsi:type='PQ' and not(@nullFlavor) and ancestor::v3:section[not(@nullFlavor)]]">
+		<validator id="288">
+			<name>RequiredNodeValidator</name>
+			<validationResultSeverityLevels>
+				<codeSeverityLevel>SHALL</codeSeverityLevel>
+			</validationResultSeverityLevels>
+            <!-- Provide an @attributeName or elementName e.g. enter '@unit' for an attribute or 'v3:observation' for an element -->
+            <requiredNodeName>@unit</requiredNodeName>
+            <!-- Provide a unique validation message for the situation. A simple version is generated from the requiredNodeName and the two are merged -->
+			<validationMessage>If Observation/value is a physical quantity (xsi:type="PQ"), the unit of measure SHALL be selected from ValueSet UnitsOfMeasureCaseSensitive 2.16.840.1.113883.1.11.12839 DYNAMIC (CONF:1198-31484).</validationMessage>
+		</validator>
+	</expression>
 	<!-- RESULT OBSERVATION END -->
 	
-    <!--  AIS TODO: Insert below rule. Add VocabularyValidationServiceTest class.  		
-    <validator id="288">
-			<name>RequiredNodeValidator</name> here with its full contents!! -->	
-
 	<!-- RESULT ORGANIZER START -->
 	<!--a. SHOULD be selected from LOINC (codeSystem 2.16.840.1.113883.6.1) OR SNOMED CT (codeSystem 2.16.840.1.113883.6.96), and MAY be selected from CPT-4 (codeSystem 2.16.840.1.113883.6.12) (CONF:1198-19218).-->
 	<!--overriding IG due to Regulation-->


### PR DESCRIPTION
Added support for RequiredNodeValidator to meet latest b1 ToC certification REQs.
Refer 
SOARAIS-2124 - Add RequiredNodeValidator support to OSS codeValidator